### PR TITLE
deploy時にslacknotifyするためのスクリプトを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,20 @@ jobs:
         env:
           CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+
+  # Slack通知処理を呼び出す
+  slack_notification:
+    # deploy_apiの後に実行されるようにする
+    needs: deploy
+    # deploy_apiが成功していても失敗していても実行されるようにする
+    if: ${{ always() }}
+    uses: ./.github/workflows/slack_notify.yml
+    with:
+      slack_channel: notify
+      # needs.<job_id>.resultで前のジョブの結果を参照できる(success、failure、cancelled、および skipped)
+      slack_color: ${{ needs.deploy_api.result == 'success' && 'good' || 'danger' }}
+      slack_username: GitHub Actions Results
+      slack_icon: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
+      slack_title: Deployment to Cloudflare Workers in ${{ github.repository }}
+      slack_message: ${{ needs.deploy_api.result == 'success' && ':white_check_mark:Deployment successful' || ':x:Deployment failed' }}
+    secrets: inherit

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -1,0 +1,46 @@
+name: Slack Notification
+
+on:
+  workflow_call:
+    inputs:
+      slack_channel:
+        description: 'The Slack channel to send the notification to'
+        required: true
+        type: string
+      slack_color:
+        description: 'The color to display in Slack'
+        required: true
+        type: string
+      slack_username:
+        description: 'The username to display in Slack'
+        required: true
+        type: string
+      slack_icon:
+        description: 'The icon to display in Slack'
+        required: true
+        type: string
+      slack_title:
+        description: 'The title to display in Slack'
+        required: true
+        type: string
+      slack_message:
+        description: 'The message to send to Slack'
+        required: true
+        type: string
+
+jobs:
+  slackNotification:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: ${{ inputs.slack_channel }}
+          SLACK_COLOR: ${{ inputs.slack_color }}
+          SLACK_USERNAME: ${{ inputs.slack_username }}
+          SLACK_ICON: ${{ inputs.slack_icon }}
+          SLACK_TITLE: ${{ inputs.slack_title }}
+          SLACK_MESSAGE: ${{ inputs.slack_message }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This pull request introduces a new Slack notification process to the CI workflow, ensuring that deployment results are communicated via Slack. The key changes include adding a new job to the CI workflow and creating a reusable workflow for Slack notifications.

### CI Workflow Enhancements:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR38-R54): Added a `slack_notification` job that runs after the `deploy_api` job, regardless of its success or failure, to send deployment results to Slack.

### Reusable Slack Notification Workflow:

* [`.github/workflows/slack_notify.yml`](diffhunk://#diff-ac46a807d4e5ab9fb6cf3f555d5402e3e513f89e3734eef80574213ac11bbea1R1-R46): Created a new reusable workflow for sending Slack notifications, which includes inputs for channel, color, username, icon, title, and message. This workflow uses the `rtCamp/action-slack-notify@v2` action to send the notifications.